### PR TITLE
Fix a bug where Streamer is restarting when client exits

### DIFF
--- a/streamer.py
+++ b/streamer.py
@@ -76,6 +76,7 @@ class Streamer(threading.Thread):
                     conn.close()
                     print('Closing connection...')
                     self.streaming = False
+                    self.running = False
                     self.jpeg = None
                     break
 


### PR DESCRIPTION
When the client exits, the streamer will restart listening for connection. This behavior causes issues with "/video_feed" page when we refresh the page. Simply exiting the streamer when the connection is close will fix that issue.